### PR TITLE
fix: implement URLSearchParams for new redirects

### DIFF
--- a/backend/download.js
+++ b/backend/download.js
@@ -11,8 +11,8 @@ module.exports = function (args, socket) {
     }
 
     const xochitlFolder = "/home/root/.local/share/remarkable/xochitl/";
-    const downloadURL = domain + args[0];
-    console.log(downloadURL);
+    const downloadURL = new URL(args[0]).searchParams.get("download_location");
+    socket.write("Fetching download from: " + downloadURL);
 
     fetch(downloadURL, fetchOptions).then((response) => {
         console.log("Redirected to:", response.url);


### PR DESCRIPTION
This PR fixes a bug with the download button not correctly linking to the PDF/ePUB when downloading- as of writing, by default, the original URL links to an online viewer that I can expect was added recently, necessitating this.